### PR TITLE
Change module type to commonjs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "es5",
-        "module": "umd",
+        "module": "commonjs",
         "outDir": ".",
         "declaration": false,
         "sourceMap": true,


### PR DESCRIPTION
Fixes "Critical dependency: require function is used in a way in which dependencies cannot be statically extracted" error.