### PR TITLE
Use generated declaration file to avoid TS2589 error with ts 3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,6 @@ typings/
 # dotenv environment variables file
 .env
 
+*.d.ts
 *.js
 *.js.map

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "2.0.1",
   "description": "A typesafe way to get nested properties when any parent property might be undefined, while we wait for the optional chaining operator to finally exist",
   "main": "index.js",
-  "types": "index.ts",
+  "types": "index.d.ts",
   "files": [
     "index.js",
     "index.js.map",
-    "index.ts"
+    "index.d.ts"
   ],
   "scripts": {
     "test": "mocha -r ts-node/register test.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "target": "es5",
         "module": "umd",
         "outDir": ".",
-        "declaration": false,
+        "declaration": true,
         "sourceMap": true,
         "strict": true
     },


### PR DESCRIPTION
The full error is
```
node_modules/typesafe-get/index.ts:21:4 - error TS2589: Type instantiation is excessively deep and possibly infinite.

21 ): Prop<Prop<Prop<Prop<Defined<T>, S1>, S2>, S3>, S4>[S5] | undefined;
```